### PR TITLE
docs: comprehensive README update for all features

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ RocketIndex was built to overcome specific limitations of existing tools:
 2.  **File Count Limits**: Unlike servers that cap indexing at ~5000 files, RocketIndex handles large monoliths (like `vets-api` with 7000+ files) with ease.
 3.  **Polyglot Core**: Powered by Tree-sitter, allowing it to support multiple languages (currently F# and Ruby) with a single binary.
 
+## Language Support
+
+| Language | Extensions | Features |
+|----------|------------|----------|
+| **F#** | `.fs`, `.fsi`, `.fsx` | Modules, functions, types, records, unions, interfaces |
+| **Ruby** | `.rb` | Classes, modules, methods, constants |
+
+Additional languages can be added via Tree-sitter grammars.
+
 ## Why not MCP?
 
 While the Model Context Protocol (MCP) is great for connecting agents to static resources (Jira, Postgres), it is the "wrong abstraction" for deep code intelligence.
@@ -48,25 +57,68 @@ While the Model Context Protocol (MCP) is great for connecting agents to static 
 
 ## CLI Usage (for Agents)
 
-All commands output JSON by default for easy integration.
+All commands output JSON by default for easy integration. Use `--concise` for minimal output (saves tokens).
+
+### Core Commands
 
 ```bash
-# Build/rebuild the index (incremental)
-$ rocketindex build
+# Index the codebase (run first!)
+$ rocketindex index
 
-# Find definition
+# Find definition (with optional git provenance)
 $ rocketindex def "PaymentService.processPayment"
-# {"file": "src/Services.fs", "line": 42, "column": 5, ...}
+$ rocketindex def "PaymentService.processPayment" --git  # Include author, date, commit
 
-# Find references
+# Search symbols (supports wildcards)
+$ rocketindex symbols "User*"
+$ rocketindex symbols "process*" --concise
+
+# Find references in a file
 $ rocketindex refs "src/Services.fs"
-
-# Spider dependency graph (explore related code)
-$ rocketindex spider "Program.main" --depth 5
-
-# Search symbols (with language filter)
-$ rocketindex symbols "User" --language ruby
 ```
+
+### Dependency Analysis
+
+```bash
+# Spider forward: what does this symbol depend on?
+$ rocketindex spider "Program.main" -d 5
+
+# Spider reverse: what depends on this symbol? (impact analysis)
+$ rocketindex spider "validateInput" --reverse -d 3
+
+# Find direct callers (single-level reverse spider)
+$ rocketindex callers "PaymentService.processPayment"
+```
+
+### Git Integration
+
+```bash
+# Git blame for a specific line
+$ rocketindex blame "src/Services.fs:42"
+
+# Git history for a symbol
+$ rocketindex history "PaymentService"
+```
+
+### Diagnostics
+
+```bash
+# Check index health
+$ rocketindex doctor
+
+# Set up editor integrations
+$ rocketindex setup claude  # Interactive skill selection
+$ rocketindex setup cursor  # Creates .cursor/rules
+```
+
+### Output Modes
+
+| Flag | Description |
+|------|-------------|
+| `--format json` | Machine-readable JSON (default) |
+| `--format pretty` | Human-readable with colors |
+| `--concise` | Minimal fields, saves tokens |
+| `--quiet` | Suppress progress output |
 
 ## IDE Integration (for Humans)
 
@@ -89,18 +141,73 @@ Binaries will be at `target/release/rocketindex` (CLI) and `target/release/rocke
 ## Agent Integration Guide
 
 ### Claude Code
-Drop-in slash commands are available in `integrations/claude-code/`. Copy these to your `.claude/commands/` directory to enable `/rocketindex-def` and `/rocketindex-spider`.
+
+The fastest way to get started:
+
+```bash
+rocketindex setup claude
+```
+
+This creates:
+- `/ri` slash command for quick access to RocketIndex commands
+- **Skills library** (optional) - 9 role-based prompts that help Claude frame tasks:
+  - **Tech Lead** - Task breakdown, code review, architectural oversight
+  - **Architect** - System design, technical decisions, ADRs
+  - **Developer** - Implementation with codebase conventions
+  - **QA Engineer** - Testing, verification, coverage
+  - **Product Manager** - Requirements, user stories, acceptance criteria
+  - **Performance Engineer** - Optimization, benchmarking, profiling
+  - **Security Engineer** - Vulnerability analysis, OWASP review
+  - **SRE** - Observability, reliability, error handling
+  - **RocketIndex** - Code navigation specialist
+
+Each skill includes bounded checklists and integrates RocketIndex commands for code navigation.
+
+### Cursor
+
+```bash
+rocketindex setup cursor
+```
+
+Creates `.cursor/rules` with RocketIndex guidance.
 
 ### Custom Agents
+
 RocketIndex follows a simple contract:
-*   **Output**: JSON (`--format json`) or Human (`--format pretty`).
-*   **Exit Codes**: `0` (Success), `1` (Not Found), `2` (Error).
-*   **Storage**: All data is persisted in `.rocketindex/index.db` (SQLite).
+
+| Aspect | Details |
+|--------|---------|
+| **Output** | JSON (`--format json`) or Human (`--format pretty`) |
+| **Exit Codes** | `0` (Success), `1` (Not Found), `2` (Error) |
+| **Storage** | `.rocketindex/index.db` (SQLite) |
+| **Token Efficiency** | Use `--concise` for minimal output |
 
 ## Limitations
 
-*   **Syntactic Only**: No compiler/runtime required. This means no type inference or overload resolution.
+*   **Syntactic Analysis Only**: No compiler/runtime required. This means no type inference or overload resolution.
 *   **No External Indexing**: Standard libraries and external packages (NuGets, Gems) are not indexed.
+*   **Approximate Resolution**: Spider dependency graphs are best-effort based on syntactic matching.
+
+## Quick Start
+
+```bash
+# 1. Build from source
+cargo build --release
+
+# 2. Index your codebase
+./target/release/rocketindex index
+
+# 3. Check health
+./target/release/rocketindex doctor
+
+# 4. Set up your editor (optional)
+./target/release/rocketindex setup claude
+
+# 5. Start exploring
+./target/release/rocketindex symbols "*Service*" --concise
+./target/release/rocketindex def "MyModule.myFunction" --git
+./target/release/rocketindex callers "validateInput"
+```
 
 ## License
 


### PR DESCRIPTION
## Summary

Comprehensive README update to document all current RocketIndex features.

## Changes

- Document all CLI commands: index, def, symbols, refs, spider, callers, blame, history, doctor, setup
- Add --concise and --git flags documentation
- Add Language Support section (F#, Ruby)
- Update Agent Integration with setup command and skills library
- Add Quick Start section
- Update output modes table

## Test plan

- [x] README renders correctly
- [x] All documented commands exist and work