### PR TITLE
feat: show git tag version in --version output

### DIFF
--- a/crates/rocketindex-cli/build.rs
+++ b/crates/rocketindex-cli/build.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+fn main() {
+    // Get version from git describe (e.g., "v0.1.0-beta.4" or "v0.1.0-beta.4-5-gabc1234")
+    let version = Command::new("git")
+        .args(["describe", "--tags", "--always"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().trim_start_matches('v').to_string())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+
+    println!("cargo:rustc-env=RKT_VERSION={}", version);
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/tags");
+}

--- a/crates/rocketindex-cli/src/main.rs
+++ b/crates/rocketindex-cli/src/main.rs
@@ -48,7 +48,7 @@ enum OutputFormat {
 /// Rocket-fast F# codebase indexing and navigation tool
 #[derive(Parser)]
 #[command(name = "rkt")]
-#[command(author, version, about, long_about = None)]
+#[command(author, version = env!("RKT_VERSION"), about, long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
Uses git describe to show full version (e.g., 0.1.0-beta.4) instead of just Cargo.toml version.