### PR TITLE
fix: use text output in interactive mode

### DIFF
--- a/crates/rocketindex-cli/src/main.rs
+++ b/crates/rocketindex-cli/src/main.rs
@@ -2015,7 +2015,9 @@ fn setup_claude_code(cwd: &Path, format: OutputFormat, quiet: bool) -> Result<u8
         }
     }
 
-    if format == OutputFormat::Json {
+    // Use text output if interactive (terminal), JSON only if explicitly requested or non-interactive
+    let is_interactive = dialoguer::console::Term::stderr().is_term();
+    if format == OutputFormat::Json && !is_interactive {
         println!(
             "{}",
             serde_json::json!({


### PR DESCRIPTION
## Summary
- Interactive terminal sessions now show text output (not JSON)
- JSON output only for non-interactive/piped usage

## Before
```
  Installed: SRE
{"created":[...], "editor":"claude-code", ...}
```

## After
```
  Installed: SRE

Setup complete! 7 file(s) created.
See .rocketindex/AGENTS.md for detailed instructions.
```