### PR TITLE
fix(lang): extract symbols from Rust macros and fix JS/TS monorepo indexing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ exclude_dirs = ["vendor", "generated"]  # Additional exclusions
 max_recursion_depth = 1000              # For deeply nested code (default: 500)
 ```
 
-Default exclusions: `node_modules`, `bin`, `obj`, `packages`, `.git`, `.vs`, `.idea`
+Default exclusions: `node_modules`, `bin`, `obj`, `.git`, `.vs`, `.idea`
 
 ## Language Support
 

--- a/crates/rocketindex/src/config.rs
+++ b/crates/rocketindex/src/config.rs
@@ -6,15 +6,10 @@ use serde::Deserialize;
 use std::path::Path;
 
 /// Default directories to exclude from indexing.
-pub const DEFAULT_EXCLUDE_DIRS: &[&str] = &[
-    "node_modules",
-    "bin",
-    "obj",
-    "packages",
-    ".git",
-    ".vs",
-    ".idea",
-];
+///
+/// Note: `packages` was removed because pnpm/npm/yarn workspaces use it for
+/// source code. NuGet packages contain mostly binaries that aren't indexed anyway.
+pub const DEFAULT_EXCLUDE_DIRS: &[&str] = &["node_modules", "bin", "obj", ".git", ".vs", ".idea"];
 
 /// RocketIndex configuration.
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
## Summary
- Fix Rust parser to extract symbols from macro invocations like `cfg_rt!`, `cfg_net!`, `cfg_if!`
- Remove `packages` from default exclusion list to support pnpm/npm/yarn workspaces
- Both fixes significantly improve symbol coverage for Rust and TypeScript/JavaScript projects

## Test plan
- [x] Unit tests for macro parsing pass
- [x] tokio repo now indexes 10,015 symbols (spawn function found at correct location)
- [x] zod repo now indexes 373 files and 8,653 symbols (was only 7 files/34 symbols)
- [x] All 315 existing tests pass